### PR TITLE
Fix indexing error when using heat pump profile

### DIFF
--- a/vgi_api/vgi_api/funcsTuring.py
+++ b/vgi_api/vgi_api/funcsTuring.py
@@ -1044,7 +1044,11 @@ class turingNet(snk.dNet):
             "hps",
         ]:
             if self.ldsi[ld]["nmv"] > 0 and ld2sd[ld] in self.p.keys():
-                pp = self.p[ld2sd[ld] + "_"]
+                if ld2sd[ld] != "lv_hp_profile_array":
+                    pp = self.p[ld2sd[ld] + "_"]
+                else:
+                    pp = self.p[ld2sd[ld]]
+
                 frac = self.ldsi[ld].nlv / self.mvlvi.nlv
                 self.dmnd[ld].mv = np.array(
                     [pp * nhses[i] * frac for i in self.ldsi[ld].mv]


### PR DESCRIPTION
The issue might be that the heat pump profiles only have one column and so we don't generate an aggregate version (i.e. a variable with '_') prepended. I changed it to use the normal non-aggregate version. This should be reviewed by @deakinmt 